### PR TITLE
Button background adjustment

### DIFF
--- a/modules/securesubmitpayment/securesubmit.css
+++ b/modules/securesubmitpayment/securesubmit.css
@@ -97,14 +97,13 @@ img.enable {
 	border-radius: 3px;
 	font-weight:bold;
 	color:#000;
-	background:url(../../themes/default/img/bg_bt.gif) repeat-x 0 0 #f4b61b;
+	background:#f4b61b;
 	cursor: pointer;
 }
-
 #securesubmit-payment-form .securesubmit-submit-button:hover, 
 #securesubmit-payment-form-cc .securesubmit-submit-button-cc:hover {
 	text-decoration:none;
-	background-position: left -50px
+	background : #FDDE78;
 }
 
 .securesubmit-payment-errors {


### PR DESCRIPTION
Because Prestashop's default theme directory is currently '/default-bootstrap/' the url for the image background on the submit button could not be found resulting in an alternate image being returned by the server. This caused undesirable visual effects on the button. This change removes the dependency on the image while maintaining a similar visual aesthetic for hover and non-hovered css states.